### PR TITLE
warning fixes : C4100 can also be issued when code calls a destructor…

### DIFF
--- a/include/eggs/variant/detail/visitor.hpp
+++ b/include/eggs/variant/detail/visitor.hpp
@@ -134,6 +134,11 @@ namespace eggs { namespace variants { namespace detail
         template <typename T>
         static void call(void* ptr)
         {
+            // https://stackoverflow.com/questions/36350338/avoid-nasty-warning-c4100-in-visual-studio
+            // C4100 can also be issued when code calls a destructor on a otherwise unreferenced parameter of primitive type.
+            // This is a limitation of the Visual C++ compiler.
+            (void)ptr;
+
             static_cast<T*>(ptr)->~T();
         }
     };


### PR DESCRIPTION
… on a otherwise unreferenced parameter of primitive type.

This is a limitation of the Visual C++ compiler.
There should a be bug report, but I cant find it at the moment.

Workarounds:

```
    Reference p otherwise:
    void destroy(pointer p) {
        (void)p;         //resolve warning C4100
        p->~T(); 
    }
```

Signed-off-by: gergely.boross <gergely.boross@aimotive.com>